### PR TITLE
adds ability to get spaces from tensor

### DIFF
--- a/src/tamm/tensor_impl.hpp
+++ b/src/tamm/tensor_impl.hpp
@@ -100,6 +100,8 @@ public:
      */
     virtual void deallocate() = 0;
 
+    auto get_spaces()const {return block_indices_;}
+
 protected:
     std::vector<TiledIndexSpace> block_indices_;
     Spin spin_total_;
@@ -261,6 +263,8 @@ public:
         // return LabeledTensor<T>{*this, IndexLabelVec{inputs...}};
         return {};
     }
+
+    auto get_spaces() const {return impl_->get_spaces();}
 
     /**
      * @brief Memory allocation method for the Tensor object


### PR DESCRIPTION
Passing the literal spaces around, along with the tensor, seems redundant given that the tensor stores the spaces; however, without passing the spaces around too there's no way to make indices.  This PR lets the user grab the spaces from within the tensor so that they can make indices if they were only given the tensor.