### PR TITLE
[SYCL] cleanup multi-tile vs single-tile discovery without the use of…

### DIFF
--- a/methods/cc/ccsd_t/ccsd_t_fused_driver.hpp
+++ b/methods/cc/ccsd_t/ccsd_t_fused_driver.hpp
@@ -99,16 +99,16 @@ ccsd_t_fused_driver_new(SystemData& sys_data, ExecutionContext& ec,
     sycl::platform platform(device_selector);
     auto const& gpu_devices = platform.get_devices();
     for (int i = 0; i < gpu_devices.size(); i++) {
-        if (gpu_devices[i].is_gpu()) {
-#ifdef TAMM_INTEL_ATS
-            auto SubDevicesDomainNuma = gpu_devices[i].create_sub_devices<sycl::info::partition_property::partition_by_affinity_domain>(sycl::info::partition_affinity_domain::numa);
-            for (const auto &tile : SubDevicesDomainNuma) {
-                dev_count_check++;
-            }
-#else
-            dev_count_check++;
-#endif
-        }
+      if (gpu_devices[i].is_gpu()) {
+	if(gpu_devices[i].get_info<cl::sycl::info::device::partition_max_sub_devices>() > 0) {
+	  auto SubDevicesDomainNuma = gpu_devices[i].create_sub_devices<cl::sycl::info::partition_property::partition_by_affinity_domain>(
+	    cl::sycl::info::partition_affinity_domain::numa);
+	  dev_count_check += SubDevicesDomainNuma.size();
+	}
+	else {
+	  dev_count_check++;
+	}
+      }
     }
 
     if(dev_count_check < nDevices) {
@@ -121,11 +121,6 @@ ccsd_t_fused_driver_new(SystemData& sys_data, ExecutionContext& ec,
                      "Terminating program..." << endl << endl;
       return std::make_tuple(-999,-999,0,0);
     }
-    // else if (dev_count_check > 1) {
-    //   if(nodezero) cout << "ERROR: TODO multi-device per node support for SYCL is not yet supported. "
-    //                     << " Terminating program..." << endl << endl;
-    //   return std::make_tuple(-999,-999,0,0);
-    // }
   }
 #else
   nDevices = 0;

--- a/methods/cc/ccsd_t/ccsd_t_unfused_driver.hpp
+++ b/methods/cc/ccsd_t/ccsd_t_unfused_driver.hpp
@@ -97,16 +97,16 @@ std::tuple<double,double,double,double> ccsd_t_unfused_driver(ExecutionContext& 
     sycl::platform platform(device_selector);
     auto const& gpu_devices = platform.get_devices();
     for (auto &gpu_device : gpu_devices) {
-	if (gpu_device.is_gpu()) {
-#ifdef TAMM_INTEL_ATS
-            auto SubDevicesDomainNuma = gpu_device.create_sub_devices<sycl::info::partition_property::partition_by_affinity_domain>(sycl::info::partition_affinity_domain::numa);
-            for (const auto &tile : SubDevicesDomainNuma) {
-                dev_count_check++;
-            }
-#else
-            dev_count_check++;
-#endif
-	}
+      if (gpu_devices[i].is_gpu()) {
+        if(gpu_devices[i].get_info<cl::sycl::info::device::partition_max_sub_devices>() > 0) {
+          auto SubDevicesDomainNuma = gpu_devices[i].create_sub_devices<cl::sycl::info::partition_property::partition_by_affinity_domain>(
+            cl::sycl::info::partition_affinity_domain::numa);
+          dev_count_check += SubDevicesDomainNuma.size();
+        }
+        else {
+          dev_count_check++;
+        }
+      }
     }
     if(dev_count_check < iDevice) {
       if(nodezero) cout << "ERROR: Please check whether you have " << iDevice <<
@@ -118,11 +118,6 @@ std::tuple<double,double,double,double> ccsd_t_unfused_driver(ExecutionContext& 
                      "Terminating program..." << endl << endl;
       return std::make_tuple(-999,-999,0,0);
     }
-    // else if (dev_count_check > 1) {
-    //   if(nodezero) cout << "ERROR: TODO multi-device per node support for SYCL is not yet supported. "
-    //                     << " Terminating program..." << endl << endl;
-    //   return std::make_tuple(-999,-999,0,0);
-    // }
   }
 #else
   iDevice = 0;

--- a/methods/cc/ccsd_t/hybrid.cpp
+++ b/methods/cc/ccsd_t/hybrid.cpp
@@ -49,16 +49,16 @@ int device_init(
   auto const& gpu_devices = platform.get_devices();
 
   for (const auto &dev : gpu_devices) {
-      if (dev.is_gpu()) {
-#ifdef TAMM_INTEL_ATS
-          auto SubDevicesDomainNuma = dev.create_sub_devices<sycl::info::partition_property::partition_by_affinity_domain>(sycl::info::partition_affinity_domain::numa);
-          for (const auto &tile : SubDevicesDomainNuma) {
-              dev_count_check++;
-          }
-#else
-      dev_count_check = gpu_devices.size();
-#endif
+    if (dev.is_gpu()) {
+      if(dev.get_info<cl::sycl::info::device::partition_max_sub_devices>() > 0) {
+        auto SubDevicesDomainNuma = dev.create_sub_devices<cl::sycl::info::partition_property::partition_by_affinity_domain>(
+          cl::sycl::info::partition_affinity_domain::numa);
+        dev_count_check += SubDevicesDomainNuma.size();
       }
+      else {
+        dev_count_check++;
+      }
+    }
   }
 #endif
 

--- a/src/tamm/execution_context.cpp
+++ b/src/tamm/execution_context.cpp
@@ -55,46 +55,38 @@ ExecutionContext::ExecutionContext(ProcGroup pg, DistributionKind default_dist_k
   sycl::platform platform(device_selector);
   auto const& gpu_devices = platform.get_devices();
   for (int i = 0; i < gpu_devices.size(); i++) {
-      if (gpu_devices[i].is_gpu()) {
-
-#ifdef TAMM_INTEL_ATS
-          assert(gpu_devices[i].get_info<sycl::info::device::partition_type_property>() ==
-                 sycl::info::partition_property::no_partition);
-
-          auto SubDevicesDomainNuma = gpu_devices[i].create_sub_devices<sycl::info::partition_property::partition_by_affinity_domain>(
-              sycl::info::partition_affinity_domain::numa);
-          for (const auto &tile : SubDevicesDomainNuma) {
-              ngpu_++;
-          }
-#else
-          ngpu_++;
-#endif
-
-      }
+    if (gpu_devices[i].is_gpu()) {
+       if(gpu_devices[i].get_info<cl::sycl::info::device::partition_max_sub_devices>() > 0) {
+         auto SubDevicesDomainNuma = gpu_devices[i].create_sub_devices<cl::sycl::info::partition_property::partition_by_affinity_domain>(
+           cl::sycl::info::partition_affinity_domain::numa);
+	 ngpu_ += SubDevicesDomainNuma.size();
+       }
+       else {
+         ngpu_++;
+       }
+     }
   }
 
   dev_id_ = ((pg.rank().value() % ranks_pn_) % ngpu_);
   if (ngpu_ == 1) dev_id_ = 0;
   if ((pg.rank().value() % ranks_pn_) < ngpu_) has_gpu_ = true;
   for (int i = 0; i < gpu_devices.size(); i++) {
-      if (gpu_devices[i].is_gpu()) {
-
-#ifdef TAMM_INTEL_ATS
-          auto SubDevicesDomainNuma = gpu_devices[i].create_sub_devices<sycl::info::partition_property::partition_by_affinity_domain>(
-              sycl::info::partition_affinity_domain::numa);
-          for (const auto &tile : SubDevicesDomainNuma) {
-              vec_syclQue.push_back( new sycl::queue( tile,
-                                                      sycl_asynchandler,
-                                                      sycl::property_list{sycl::property::queue::in_order{}} ) );
-          }
-#else
-          vec_syclQue.push_back( new sycl::queue( gpu_devices[i],
-                                                  sycl_asynchandler,
-                                                  sycl::property_list{sycl::property::queue::in_order{}} ) );
-#endif
-      }
+    if (gpu_devices[i].is_gpu()) {
+       if(gpu_devices[i].get_info<cl::sycl::info::device::partition_max_sub_devices>() > 0) {
+         auto SubDevicesDomainNuma = gpu_devices[i].create_sub_devices<cl::sycl::info::partition_property::partition_by_affinity_domain>(
+           cl::sycl::info::partition_affinity_domain::numa);
+         for (const auto &tile : SubDevicesDomainNuma) {
+           vec_syclQue.push_back( new sycl::queue(tile, sycl_asynchandler,
+                                                  sycl::property_list{sycl::property::queue::in_order{}}) );
+         }
+       }
+       else {
+         vec_syclQue.push_back( new sycl::queue(gpu_devices[i], sycl_asynchandler,
+                                                sycl::property_list{sycl::property::queue::in_order{}}) );
+       }
+     }
   }
-#endif
+#endif // USE_DPCPP
   // memory_manager_local_ = MemoryManagerLocal::create_coll(pg_self_);
 }
 


### PR DESCRIPTION
… TAMM_INTEL_ATS macro

Minor cleanup to unify detection/creation of multi-tile and single-tile Intel devices. TAMM_INTEL_ATS macro is removed.
 
<!--- All PRs will be manually reviewed prior to acceptance. They also must
      pass CI testing. --->

## Status

<!--- Please check this box when your PR is ready to be reviewed --->
- [x] Ready to go


## Brief Description

<!--- One or two sentences to quickly describe what your PR does --->

## Detailed Description (optional)

## TODOs and/or Questions (optional)

<!--- If you are opening your PR early, so as to tell us what you are working
      on, it can be useful to have a checklist of what you plan to do and
      what you are unsure of.  That goes here --->
      
