### PR TITLE
MAINT: Don't make assumptions about user environs

### DIFF
--- a/cmake/check_user_env.cmake
+++ b/cmake/check_user_env.cmake
@@ -7,11 +7,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "XL"
         message(FATAL_ERROR "TAMM cannot be currently built with ${CMAKE_CXX_COMPILER_ID} compilers.")
 endif()
 
-if (DEFINED ENV{CONDA_PREFIX}) #VIRTUAL_ENV
-  message(FATAL_ERROR "TAMM cannot be currently built with CONDA. \
-          Please deactivate CONDA environment.")
-endif()
-
 if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Darwin")
     if (${PROJECT_NAME}_ENABLE_CUDA)
         message(FATAL_ERROR "${PROJECT_NAME} does not support building with GPU support \


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Nope

**Description**
It might be easier to reason about debugging if you only allow one reference machine, but making such strong assumptions is a very bad idea.

Also, in any case, `conda` works fine with TAMM.